### PR TITLE
Decimal to Binary with Dynamic Length works?

### DIFF
--- a/static/extensions/BurningHot687/bitsandhexa.js
+++ b/static/extensions/BurningHot687/bitsandhexa.js
@@ -20,102 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 */
 
-// V0.13
-
-let fullLength = true;
-let extOpen = false;
-let basesArray = ["decimal", "binary", "hexadecimal"];
-const extBlockArray = [
-    {
-        opcode: "bitHexConfigurationLabel",
-        text: "Configuration Settings ⚠",
-        blockType: Scratch.BlockType.LABEL,
-    },
-    {
-        opcode: "binaryLengthSetter",
-        text: "use a [LENGTH] length for binary",
-        blockType: Scratch.BlockType.COMMAND,
-        arguments: {
-            LENGTH: {
-                type: Scratch.ArgumentType.STRING,
-                menu: "LENGTHS",
-            }
-        },
-    },
-    {
-        opcode: "binaryLengthGetter",
-        text: "using [LENGTH] length?",
-        blockType: Scratch.BlockType.BOOLEAN,
-        label: "using fixed length",
-        arguments: {
-            LENGTH: {
-                type: Scratch.ArgumentType.STRING,
-                menu: "LENGTHS",
-            },
-        },
-    },
-];
-const icon = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAyMjUgMjI1Ij4KICA8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMjkuNS4xLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogMi4xLjAgQnVpbGQgMTQxKSAgLS0+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5zdDAgewogICAgICAgIGZpbGw6ICNmZmY7CiAgICAgIH0KCiAgICAgIC5zdDEgewogICAgICAgIGZpbGw6ICMxYjQ2OGQ7CiAgICAgIH0KCiAgICAgIC5zdDIgewogICAgICAgIGZpbGw6ICMxNDY0OGE7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDxyZWN0IGNsYXNzPSJzdDEiIHdpZHRoPSIyMjUiIGhlaWdodD0iMjI1Ii8+CiAgPGc+CiAgICA8cG9seWdvbiBjbGFzcz0ic3QwIiBwb2ludHM9IjE3NC4wNiAxNC4wMSAxMTkuMjEgMTQuMDEgOTEuNzkgNjEuNTEgMTE5LjIxIDEwOS4wMSAxNzQuMDYgMTA5LjAxIDIwMS40OSA2MS41MSAxNzQuMDYgMTQuMDEiLz4KICAgIDxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjY1LjY1IiBjeT0iMTIyLjI2IiByPSI0Mi4xNCIvPgogICAgPHJlY3QgY2xhc3M9InN0MCIgeD0iMTE3LjE3IiB5PSIxMTcuOCIgd2lkdGg9Ijc0LjE4IiBoZWlnaHQ9IjkzLjE5IiByeD0iMTIiIHJ5PSIxMiIvPgogIDwvZz4KPC9zdmc+";
-const iconCircle = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAyMjUgMjI1Ij4KICA8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMjkuNS4xLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogMi4xLjAgQnVpbGQgMTQxKSAgLS0+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5zdDAgewogICAgICAgIGZpbGw6ICMxNDY0OGE7CiAgICAgIH0KCiAgICAgIC5zdDEgewogICAgICAgIGZpbGw6ICNmZmY7CiAgICAgIH0KCiAgICAgIC5zdDIgewogICAgICAgIGZpbGw6ICMxYjQ2OGQ7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDxyZWN0IGNsYXNzPSJzdDIiIHg9IjAiIHk9IjAiIHdpZHRoPSIyMjUiIGhlaWdodD0iMjI1IiByeD0iMTEyLjUiIHJ5PSIxMTIuNSIvPgogIDxnPgogICAgPHBvbHlnb24gY2xhc3M9InN0MSIgcG9pbnRzPSIxNjMuODUgMzAuMzQgMTE4LjEgMzAuMzQgOTUuMjIgNjkuOTcgMTE4LjEgMTA5LjU5IDE2My44NSAxMDkuNTkgMTg2LjczIDY5Ljk3IDE2My44NSAzMC4zNCIvPgogICAgPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iNzMuNDIiIGN5PSIxMjAuNjQiIHI9IjM1LjE1Ii8+CiAgICA8cmVjdCBjbGFzcz0ic3QxIiB4PSIxMTYuNCIgeT0iMTE2LjkyIiB3aWR0aD0iNjEuODgiIGhlaWdodD0iNzcuNzQiIHJ4PSIxMC4wMSIgcnk9IjEwLjAxIi8+CiAgPC9nPgogIDxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik01MS41MSwxOTAuMjNjLTMuNjksMC0zLjY5LDUuNzMsMCw1LjczczMuNjktNS43MywwLTUuNzNaIi8+CiAgPHBhdGggY2xhc3M9InN0MSIgZD0iTTcwLjk3LDE3OS4wM2MtMy42OSwwLTMuNjksNS43MywwLDUuNzNzMy42OS01LjczLDAtNS43M1oiLz4KICA8cGF0aCBjbGFzcz0ic3QxIiBkPSJNNjYuNzcsMTkzLjF2MS40NGMtLjI2LS4xNS0uNTEtLjMtLjc2LS40NS0zLjE0LTEuOTYtNi4wMiwzLTIuODksNC45NSwxLjA3LjY3LDIuMTksMS4yMiwzLjM2LDEuNywxLjI4LjUzLDIuNjMsMS4wMywzLjk5LjQsMS42NS0uNzYsMi4wMy0yLjM2LDIuMDQtNC4wM3YtNC4wMWMwLTMuNjktNS43Mi0zLjY5LTUuNzMsMFoiLz4KPC9zdmc+";
-
-function isInCorrectFormat(inputString) {
-    if ((inputString != parseInt(inputString, 10).toString(10)) && !isItHexadecimal(inputString)) {
-        console.log("bad string")
-        return false;
-    }
-    console.log("good string");
-    return true;
-};
-
-function isItHexadecimal(inputString) {
-    return !/[^abcdef0123456789]/i.test(inputString);
-};
-
-function isItDecimal(inputString) {
-    return !/[^0123456789-]/.test(inputString);
-};
-
-function isItBinary(inputString) {
-    return !/[^01]/.test(inputString);
-};
-
-function testForFormat(numString, base) {
-    switch (basesArray.indexOf(base)) {
-        case 0:
-            return isItDecimal(numString);
-        case 1:
-            return isItBinary(numString);
-        case 2:
-            return isItHexadecimal(numString);
-    }
-};
-
-function binaryReformat(Value, neg = true) {
-    let newValue = Math.abs(Value).toString(2).length + 1;
-    let computedValue = (Value >>> 0).toString(2);
-    if (!fullLength) {
-        console.log(computedValue);
-        console.log(newValue);
-        if (neg) computedValue = computedValue.slice(clamp(computedValue.length - newValue, 0, computedValue.length), computedValue.length);
-        if (!neg) computedValue = "0" + computedValue
-        console.log(computedValue);
-    }
-    return computedValue;
-};
-
-function clamp(value, min, max) {
-    console.log(Math.max(min, Math.min(value, max)))
-    return Math.max(min, Math.min(value, max));
-};
-
-function binaryToDecimal(computedValue) {
-    let newerValue = 0;
-    for (let i = computedValue.length; i > 0; i--) {
-        newerValue += parseInt(computedValue[i]) * (Math.pow(2, computedValue.length - i)) * ((i === 0) ? -1 : 1);
-    }
-    console.log(newerValue);
-    return newerValue;
-};
+// V0.14
 
 (function(Scratch){
     "use strict";
@@ -123,6 +28,102 @@ function binaryToDecimal(computedValue) {
     if (!Scratch.extensions.unsandboxed) {
         // throw new Error("This extension prefers to be used unsandboxed");
     }
+
+    let fullLength = true;
+    let selLengthIsFull = true;
+    let extOpen = false;
+    let basesArray = ["decimal", "binary", "hexadecimal"];
+    const extBlockArray = [
+        {
+            opcode: "bitHexConfigurationLabel",
+            text: "Configuration Settings ⚠",
+            blockType: Scratch.BlockType.LABEL,
+        },
+        {
+            opcode: "binaryLengthSetter",
+            text: "use a [LENGTH] length for binary",
+            blockType: Scratch.BlockType.COMMAND,
+            arguments: {
+                LENGTH: {
+                    type: Scratch.ArgumentType.STRING,
+                    menu: "LENGTHS",
+                }
+            },
+        },
+        {
+            opcode: "binaryLengthGetter",
+            text: "using [LENGTH] length?",
+            blockType: Scratch.BlockType.BOOLEAN,
+            label: selLengthIsFull ? "using fixed length" : "using dynamic length",
+            arguments: {
+                LENGTH: {
+                    type: Scratch.ArgumentType.STRING,
+                    menu: "LENGTHS",
+                },
+            },
+        },
+    ];
+    const icon = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAyMjUgMjI1Ij4KICA8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMjkuNS4xLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogMi4xLjAgQnVpbGQgMTQxKSAgLS0+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5zdDAgewogICAgICAgIGZpbGw6ICNmZmY7CiAgICAgIH0KCiAgICAgIC5zdDEgewogICAgICAgIGZpbGw6ICMxYjQ2OGQ7CiAgICAgIH0KCiAgICAgIC5zdDIgewogICAgICAgIGZpbGw6ICMxNDY0OGE7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDxyZWN0IGNsYXNzPSJzdDEiIHdpZHRoPSIyMjUiIGhlaWdodD0iMjI1Ii8+CiAgPGc+CiAgICA8cG9seWdvbiBjbGFzcz0ic3QwIiBwb2ludHM9IjE3NC4wNiAxNC4wMSAxMTkuMjEgMTQuMDEgOTEuNzkgNjEuNTEgMTE5LjIxIDEwOS4wMSAxNzQuMDYgMTA5LjAxIDIwMS40OSA2MS41MSAxNzQuMDYgMTQuMDEiLz4KICAgIDxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjY1LjY1IiBjeT0iMTIyLjI2IiByPSI0Mi4xNCIvPgogICAgPHJlY3QgY2xhc3M9InN0MCIgeD0iMTE3LjE3IiB5PSIxMTcuOCIgd2lkdGg9Ijc0LjE4IiBoZWlnaHQ9IjkzLjE5IiByeD0iMTIiIHJ5PSIxMiIvPgogIDwvZz4KPC9zdmc+";
+    const iconCircle = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAyMjUgMjI1Ij4KICA8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMjkuNS4xLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogMi4xLjAgQnVpbGQgMTQxKSAgLS0+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5zdDAgewogICAgICAgIGZpbGw6ICMxNDY0OGE7CiAgICAgIH0KCiAgICAgIC5zdDEgewogICAgICAgIGZpbGw6ICNmZmY7CiAgICAgIH0KCiAgICAgIC5zdDIgewogICAgICAgIGZpbGw6ICMxYjQ2OGQ7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDxyZWN0IGNsYXNzPSJzdDIiIHg9IjAiIHk9IjAiIHdpZHRoPSIyMjUiIGhlaWdodD0iMjI1IiByeD0iMTEyLjUiIHJ5PSIxMTIuNSIvPgogIDxnPgogICAgPHBvbHlnb24gY2xhc3M9InN0MSIgcG9pbnRzPSIxNjMuODUgMzAuMzQgMTE4LjEgMzAuMzQgOTUuMjIgNjkuOTcgMTE4LjEgMTA5LjU5IDE2My44NSAxMDkuNTkgMTg2LjczIDY5Ljk3IDE2My44NSAzMC4zNCIvPgogICAgPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iNzMuNDIiIGN5PSIxMjAuNjQiIHI9IjM1LjE1Ii8+CiAgICA8cmVjdCBjbGFzcz0ic3QxIiB4PSIxMTYuNCIgeT0iMTE2LjkyIiB3aWR0aD0iNjEuODgiIGhlaWdodD0iNzcuNzQiIHJ4PSIxMC4wMSIgcnk9IjEwLjAxIi8+CiAgPC9nPgogIDxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik01MS41MSwxOTAuMjNjLTMuNjksMC0zLjY5LDUuNzMsMCw1LjczczMuNjktNS43MywwLTUuNzNaIi8+CiAgPHBhdGggY2xhc3M9InN0MSIgZD0iTTcwLjk3LDE3OS4wM2MtMy42OSwwLTMuNjksNS43MywwLDUuNzNzMy42OS01LjczLDAtNS43M1oiLz4KICA8cGF0aCBjbGFzcz0ic3QxIiBkPSJNNjYuNzcsMTkzLjF2MS40NGMtLjI2LS4xNS0uNTEtLjMtLjc2LS40NS0zLjE0LTEuOTYtNi4wMiwzLTIuODksNC45NSwxLjA3LjY3LDIuMTksMS4yMiwzLjM2LDEuNywxLjI4LjUzLDIuNjMsMS4wMywzLjk5LjQsMS42NS0uNzYsMi4wMy0yLjM2LDIuMDQtNC4wM3YtNC4wMWMwLTMuNjktNS43Mi0zLjY5LTUuNzMsMFoiLz4KPC9zdmc+";
+
+    function isInCorrectFormat(inputString) {
+        if ((inputString != parseInt(inputString, 10).toString(10)) && !isItHexadecimal(inputString)) {
+            console.log("bad string")
+            return false;
+        }
+        console.log("good string");
+        return true;
+    };
+
+    function isItHexadecimal(inputString) {
+        return !/[^abcdef0123456789]/i.test(inputString);
+    };
+
+    function isItDecimal(inputString) {
+        return !/[^0123456789-]/.test(inputString);
+    };
+
+    function isItBinary(inputString) {
+        return !/[^01]/.test(inputString);
+    };
+
+    function testForFormat(numString, base) {
+        switch (basesArray.indexOf(base)) {
+            case 0:
+                return isItDecimal(numString);
+            case 1:
+                return isItBinary(numString);
+            case 2:
+                return isItHexadecimal(numString);
+        }
+    };
+
+    function binaryReformat(Value, neg = true) {
+        let newValue = Math.abs(Value).toString(2).length + 1;
+        let computedValue = (Value >>> 0).toString(2);
+        if (!fullLength) {
+            console.log(computedValue);
+            console.log(newValue);
+            if (neg) computedValue = computedValue.slice(clamp(computedValue.length - newValue, 0, computedValue.length), computedValue.length);
+            if (!neg) computedValue = "0" + computedValue
+            console.log(computedValue);
+        }
+        return computedValue;
+    };
+
+    function clamp(value, min, max) {
+        console.log(Math.max(min, Math.min(value, max)))
+        return Math.max(min, Math.min(value, max));
+    };
+
+    function binaryToDecimal(computedValue) {
+        let newerValue = 0;
+        for (let i = computedValue.length; i > 0; i--) {
+            newerValue += parseInt(computedValue[i - 1]) * (Math.pow(2, computedValue.length - i)) * ((i === 0) ? -1 : 1);
+        }
+        console.log(newerValue);
+        return newerValue;
+    };
 
     class Extension {
         getInfo() {
@@ -136,15 +137,8 @@ function binaryToDecimal(computedValue) {
                 menuIconURI: iconCircle,
                 blockIconURI: icon,
                 isDynamic: true,
-                /*function orderBlocks(blocks) {
-                    if (extOpen) {
-                        return mainBlockArray.concat(extBlockArray);
-                    }
-                        return mainBlockArray;
-                };*/
 
                 blocks: [
-                    "---",
                     {
                         opcode: "bitwiseDocumentationButton",
                         text: "Open Documentation",
@@ -353,6 +347,7 @@ function binaryToDecimal(computedValue) {
                         },
                         switches: [ 'bitwiseOrOperator', 'bitwiseAndOperator', 'bitwiseNotOperator', 'bitwiseNandOperator', 'bitwiseNorOperator', 'bitwiseXnorOperator' ],
                     },
+                    "---",
                     {
                         opcode: "bitwiseNotOperator",
                         text: "~[NUM] | not",
@@ -449,10 +444,13 @@ function binaryToDecimal(computedValue) {
         }
 
         binaryLengthGetter(args) {
+            // Still need to fix monitors here lol
             switch (args.LENGTH) {
                 case 'fixed':
+                    selLengthIsFull = true;
                     return fullLength;
                 case 'dynamic':
+                    selLengthIsFull = false;
                     return !fullLength;
                 default:
                     console.log("error here?");
@@ -510,7 +508,7 @@ function binaryToDecimal(computedValue) {
                         computeValue = binaryToDecimal(computeValue);
                         break;
                     case 2:
-                        computeValue = binaryToDecimal(parseInt(computeValue, 16).toString(2));
+                        computeValue = binaryToDecimal((parseInt(computeValue, 16) >>> 0).toString(2));
                         break;
                 }
             }
@@ -523,12 +521,7 @@ function binaryToDecimal(computedValue) {
                     computeValue = binaryReformat(computeValue, computeValue < 0);
                     break;
                 case 2:
-                    /*if (computeValue < 0) {
-                        computeValue = Math.abs(computeValue);
-                        computeValue = ~computeValue;
-                        computeValue++;
-                    }*/
-                    computeValue = (parseInt(binaryReformat(computeValue, computeValue < 0), 2) >>> 0).toString(16);
+                    computeValue = fullLength ? computeValue.toString(16) : parseInt(binaryReformat(computeValue, computeValue < 0), 2).toString(16);
                     break;
                 default:
                     console.log("failed?");
@@ -539,13 +532,14 @@ function binaryToDecimal(computedValue) {
         }
 
         getBitAtIdx(args) {
-            if (args.AMOUNT > 31) return "";
+            if (args.IDX > 31) return "";
             let computeValue = args.NUM;
             if (!(isItDecimal(computeValue) || isItHexadecimal(computeValue))) return "";
             if (isItHexadecimal(computeValue) && /[abcdef]/i.test(computeValue)) {
                 computeValue = "0x" + computeValue;
             }
-            return (computeValue >> args.IDX) & 1;
+            if (args.IDX > parseInt(computeValue, 2).length && !fullLength) return "";
+            return (parseInt(computeValue) >> args.IDX) & 1;
         }
 
         signedRightShiftBitz(args) {

--- a/static/extensions/BurningHot687/bitsandhexa.js
+++ b/static/extensions/BurningHot687/bitsandhexa.js
@@ -128,7 +128,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             const extraBlocks = extOpen ? extBlockArray : [];
             return {
                 id: "burninghot687bitwisewhexa",
-                name: Scratch.translate("Bits and Hexa"),
+                name: Scratch.translate("Bitwise") + "+",
                 color1: "#15448f",
                 color2: "#0f1f70",
                 color3: "#0a094f",

--- a/static/extensions/BurningHot687/bitsandhexa.js
+++ b/static/extensions/BurningHot687/bitsandhexa.js
@@ -15,7 +15,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
     TO-DO:
 
-    - Add more of the blocks that TrueFantom had
     - Get feedback
 
 */
@@ -35,7 +34,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     let basesArray = ["decimal", "binary", "hexadecimal"];
     const extBlockArray = [
         {
-            opcode: "bitHexConfigurationLabel",
             text: "Configuration Settings ⚠",
             blockType: Scratch.BlockType.LABEL,
         },
@@ -119,7 +117,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     function binaryToDecimal(computedValue) {
         let newerValue = 0;
         for (let i = computedValue.length; i > 0; i--) {
-            newerValue += parseInt(computedValue[i - 1]) * (Math.pow(2, computedValue.length - i)) * ((i === 0) ? -1 : 1);
+            newerValue += parseInt(computedValue[i - 1]) * (Math.pow(2, computedValue.length - i)) * ((i === 1) ? -1 : 1);
         }
         console.log(newerValue);
         return newerValue;
@@ -200,7 +198,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
                         },
                     },
                     {
-                        opcode: "bitHexManipulationLabel",
                         text: "Bitwise Manipulation",
                         blockType: Scratch.BlockType.LABEL,
                     },
@@ -295,7 +292,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
                         switches: [ "signedRightShiftBitz", "leftShiftBitz", "unsignedRightShiftBitz", "circularRightShiftBitz" ],
                     },
                     {
-                        opcode: "bitHexBitwiseOperatorsLabel",
                         text: "Bitwise Operators",
                         blockType: Scratch.BlockType.LABEL,
                     },
@@ -440,7 +436,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         }
 
         bitwiseDocumentationButton() {
-            window.location.href = "https://docs.penguinmod.com/extensions/bitsandhexa";
+            window.location.href = "https://extensions.penguinmod.com/docs/bitsandhexa";
         }
 
         binaryLengthGetter(args) {

--- a/static/extensions/BurningHot687/bitsandhexa.js
+++ b/static/extensions/BurningHot687/bitsandhexa.js
@@ -20,10 +20,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 */
 
-// V0.11
+// V0.12
 
-var fullLength = true;
-var basesArray = ["decimal", "binary", "hexadecimal"];
+let fullLength = true;
+let extOpen = false;
+let basesArray = ["decimal", "binary", "hexadecimal"];
+const mainBlockArray = [];
+const extBlockArray = [];
 const icon = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAyMjUgMjI1Ij4KICA8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMjkuNS4xLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogMi4xLjAgQnVpbGQgMTQxKSAgLS0+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5zdDAgewogICAgICAgIGZpbGw6ICNmZmY7CiAgICAgIH0KCiAgICAgIC5zdDEgewogICAgICAgIGZpbGw6ICMxYjQ2OGQ7CiAgICAgIH0KCiAgICAgIC5zdDIgewogICAgICAgIGZpbGw6ICMxNDY0OGE7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDxyZWN0IGNsYXNzPSJzdDEiIHdpZHRoPSIyMjUiIGhlaWdodD0iMjI1Ii8+CiAgPGc+CiAgICA8cG9seWdvbiBjbGFzcz0ic3QwIiBwb2ludHM9IjE3NC4wNiAxNC4wMSAxMTkuMjEgMTQuMDEgOTEuNzkgNjEuNTEgMTE5LjIxIDEwOS4wMSAxNzQuMDYgMTA5LjAxIDIwMS40OSA2MS41MSAxNzQuMDYgMTQuMDEiLz4KICAgIDxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjY1LjY1IiBjeT0iMTIyLjI2IiByPSI0Mi4xNCIvPgogICAgPHJlY3QgY2xhc3M9InN0MCIgeD0iMTE3LjE3IiB5PSIxMTcuOCIgd2lkdGg9Ijc0LjE4IiBoZWlnaHQ9IjkzLjE5IiByeD0iMTIiIHJ5PSIxMiIvPgogIDwvZz4KPC9zdmc+";
 const iconCircle = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAyMjUgMjI1Ij4KICA8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMjkuNS4xLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogMi4xLjAgQnVpbGQgMTQxKSAgLS0+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5zdDAgewogICAgICAgIGZpbGw6ICMxNDY0OGE7CiAgICAgIH0KCiAgICAgIC5zdDEgewogICAgICAgIGZpbGw6ICNmZmY7CiAgICAgIH0KCiAgICAgIC5zdDIgewogICAgICAgIGZpbGw6ICMxYjQ2OGQ7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDxyZWN0IGNsYXNzPSJzdDIiIHg9IjAiIHk9IjAiIHdpZHRoPSIyMjUiIGhlaWdodD0iMjI1IiByeD0iMTEyLjUiIHJ5PSIxMTIuNSIvPgogIDxnPgogICAgPHBvbHlnb24gY2xhc3M9InN0MSIgcG9pbnRzPSIxNjMuODUgMzAuMzQgMTE4LjEgMzAuMzQgOTUuMjIgNjkuOTcgMTE4LjEgMTA5LjU5IDE2My44NSAxMDkuNTkgMTg2LjczIDY5Ljk3IDE2My44NSAzMC4zNCIvPgogICAgPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iNzMuNDIiIGN5PSIxMjAuNjQiIHI9IjM1LjE1Ii8+CiAgICA8cmVjdCBjbGFzcz0ic3QxIiB4PSIxMTYuNCIgeT0iMTE2LjkyIiB3aWR0aD0iNjEuODgiIGhlaWdodD0iNzcuNzQiIHJ4PSIxMC4wMSIgcnk9IjEwLjAxIi8+CiAgPC9nPgogIDxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik01MS41MSwxOTAuMjNjLTMuNjksMC0zLjY5LDUuNzMsMCw1LjczczMuNjktNS43MywwLTUuNzNaIi8+CiAgPHBhdGggY2xhc3M9InN0MSIgZD0iTTcwLjk3LDE3OS4wM2MtMy42OSwwLTMuNjksNS43MywwLDUuNzNzMy42OS01LjczLDAtNS43M1oiLz4KICA8cGF0aCBjbGFzcz0ic3QxIiBkPSJNNjYuNzcsMTkzLjF2MS40NGMtLjI2LS4xNS0uNTEtLjMtLjc2LS40NS0zLjE0LTEuOTYtNi4wMiwzLTIuODksNC45NSwxLjA3LjY3LDIuMTksMS4yMiwzLjM2LDEuNywxLjI4LjUzLDIuNjMsMS4wMywzLjk5LjQsMS42NS0uNzYsMi4wMy0yLjM2LDIuMDQtNC4wM3YtNC4wMWMwLTMuNjktNS43Mi0zLjY5LTUuNzMsMFoiLz4KPC9zdmc+";
 
@@ -59,6 +62,33 @@ function testForFormat(numString, base) {
     }
 };
 
+function binaryReformat(Value, neg = true) {
+    let newValue = Math.abs(Value).toString(2).length + 1;
+    let computedValue = (Value >>> 0).toString(2);
+    if (!fullLength) {
+        console.log(computedValue);
+        console.log(newValue);
+        if (neg) computedValue = computedValue.slice(clamp(computedValue.length - newValue, 0, computedValue.length), computedValue.length);
+        if (!neg) computedValue = "0" + computedValue
+        console.log(computedValue);
+    }
+    return computedValue;
+};
+
+function clamp(value, min, max) {
+    console.log(Math.max(min, Math.min(value, max)))
+    return Math.max(min, Math.min(value, max));
+};
+
+function binaryToDecimal(computedValue) {
+    let newerValue = 0;
+    for (let i = computedValue.length; i > 0; i--) {
+        newerValue += parseInt(computedValue[i]) * (Math.pow(2, computedValue.length - i)) * ((i === 0) ? -1 : 1);
+    }
+    console.log(newerValue);
+    return newerValue;
+};
+
 (function(Scratch){
     "use strict";
 
@@ -76,8 +106,22 @@ function testForFormat(numString, base) {
                 color3: "#0a094f",
                 menuIconURI: iconCircle,
                 blockIconURI: icon,
+                // isDynamic: true,
+                /*function orderBlocks(blocks) {
+                    if (extOpen) {
+                        return mainBlockArray.concat(extBlockArray);
+                    }
+                        return mainBlockArray;
+                };*/
 
                 blocks: [
+                    "---",
+                    {
+                        opcode: "bitwiseDocumentationButton",
+                        text: "Open Documentation",
+                        blockType: Scratch.BlockType.BUTTON,
+                        hideFromPalette: true,
+                    },
                     {
                         opcode: "isNumActuallyBase",
                         text: "is [NUM] [BASE]?",
@@ -116,6 +160,23 @@ function testForFormat(numString, base) {
                         },
                     },
                     {
+                        opcode: "getBitAtIdx",
+                        text: "get bit at index [IDX] of [NUM]",
+                        blockType: Scratch.BlockType.REPORTER,
+                        disableMonitor: true,
+                        allowDropAnywhere: true,
+                        arguments: {
+                            IDX: {
+                                type: Scratch.ArgumentType.NUMBER,
+                                defaultValue: 3,
+                            },
+                            NUM: {
+                                type: Scratch.ArgumentType.STRING,
+                                defaultValue: '13',
+                            },
+                        },
+                    },
+                    {
                         opcode: "bitHexManipulationLabel",
                         text: "Bitwise Manipulation",
                         blockType: Scratch.BlockType.LABEL,
@@ -123,12 +184,13 @@ function testForFormat(numString, base) {
                     {
                         opcode: "signedRightShiftBitz",
                         text: "[NUM] >> [AMOUNT]",
+                        switchText: ">>",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
                             NUM: {
                                 type: Scratch.ArgumentType.STRING,
-                                defaultValue: "4b2",
+                                defaultValue: "4d2",
                             },
                             AMOUNT: {
                                 type: Scratch.ArgumentType.NUMBER,
@@ -140,6 +202,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "leftShiftBitz",
                         text: "[NUM] << [AMOUNT]",
+                        switchText: "<<",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -157,6 +220,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "unsignedRightShiftBitz",
                         text: "[NUM] >>> [AMOUNT]",
+                        switchText: ">>>",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -174,6 +238,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "circularRightShiftBitz",
                         text: "[NUM] ↻ [AMOUNT]",
+                        switchText: "↻",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -191,6 +256,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "circularLeftShiftBitz",
                         text: "[NUM] ↺ [AMOUNT]",
+                        switchText: "↺",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -213,6 +279,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "bitwiseAndOperator",
                         text: "[NUM] & [NUM2] | and",
+                        switchText: "& and",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -228,6 +295,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "bitwiseOrOperator",
                         text: "[NUM] | [NUM2] | or",
+                        switchText: "| or",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -243,6 +311,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "bitwiseXorOperator",
                         text: "[NUM] ^ [NUM2] | xor",
+                        switchText: "^ xor",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -258,6 +327,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "bitwiseNotOperator",
                         text: "~[NUM] | not",
+                        switchText: "~ not",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -270,6 +340,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "bitwiseNandOperator",
                         text: "~[NUM] & [NUM2] | nand",
+                        switchText: "~& nand",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -285,6 +356,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "bitwiseNorOperator",
                         text: "~[NUM] | [NUM2] | nor",
+                        switchText: "~| nor",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -300,6 +372,7 @@ function testForFormat(numString, base) {
                     {
                         opcode: "bitwiseXnorOperator",
                         text: "~[NUM] ^ [NUM2] | xnor",
+                        switchText: "~^ xnor",
                         blockType: Scratch.BlockType.REPORTER,
                         disableMonitor: true,
                         arguments: {
@@ -332,6 +405,7 @@ function testForFormat(numString, base) {
                         opcode: "binaryLengthGetter",
                         text: "using [LENGTH] length?",
                         blockType: Scratch.BlockType.BOOLEAN,
+                        label: "using fixed length",
                         arguments: {
                             LENGTH: {
                                 type: Scratch.ArgumentType.STRING,
@@ -357,6 +431,10 @@ function testForFormat(numString, base) {
             };
         }
         
+        bitwiseDocumentationButton() {
+            window.location.href = "https://docs.penguinmod.com/extensions/bitsandhexa";
+        }
+
         binaryLengthGetter(args) {
             switch (args.LENGTH) {
                 case 'fixed':
@@ -384,7 +462,7 @@ function testForFormat(numString, base) {
         }
 
         isNumActuallyBase(args) {
-            var computeValue = args.NUM;
+            let computeValue = args.NUM;
             if (isInCorrectFormat(computeValue) === false) {
                 return false;
             }
@@ -393,7 +471,7 @@ function testForFormat(numString, base) {
         }
 
         convertBaseTypesBitW(args) {
-            var computeValue = args.NUM;
+            let computeValue = args.NUM;
             console.log(args.FROM);
             console.log(args.BASE);
             if (isInCorrectFormat(computeValue) === false) {
@@ -403,24 +481,33 @@ function testForFormat(numString, base) {
                 console.log("not same as [from]");
                 return "";
             }
-           if (args.FROM === args.BASE) {
+            if (args.FROM === args.BASE) {
                 console.log("same!");
                 // return args.NUM;
-           }
-            computeValue = parseInt(computeValue, (args.FROM === basesArray[0]) ? 10 : ((args.FROM === basesArray[1]) ? 2: 16));
+            }
+            if (fullLength) {
+                computeValue = parseInt(computeValue, (args.FROM === basesArray[0]) ? 10 : ((args.FROM === basesArray[1]) ? 2: 16));
+            } else {
+                console.log("dynamic adjust")
+                switch (basesArray.indexOf(args.FROM)) {
+                    case 0:
+                        computeValue = parseInt(computeValue);
+                        break;
+                    case 1:
+                        computeValue = binaryToDecimal(computeValue);
+                        break;
+                    case 2:
+                        computeValue = binaryToDecimal(parseInt(computeValue, 16).toString(2));
+                        break;
+                }
+            }
 
             switch (basesArray.indexOf(args.BASE)) {
                 case 0:
                     computeValue = computeValue.toString(10);
                     break;
                 case 1:
-                    /*if (computeValue < 0) {
-                        console.log("huh cool");
-                        computeValue = Math.abs(computeValue);
-                        computeValue = ~computeValue;
-                        computeValue++;
-                    }*/
-                    computeValue = (computeValue >>> 0).toString(2);
+                    computeValue = binaryReformat(computeValue, computeValue < 0);
                     break;
                 case 2:
                     /*if (computeValue < 0) {
@@ -428,7 +515,7 @@ function testForFormat(numString, base) {
                         computeValue = ~computeValue;
                         computeValue++;
                     }*/
-                    computeValue = (computeValue >>> 0).toString(16);
+                    computeValue = (parseInt(binaryReformat(computeValue, computeValue < 0), 2) >>> 0).toString(16);
                     break;
                 default:
                     console.log("failed?");
@@ -438,8 +525,18 @@ function testForFormat(numString, base) {
             return computeValue;
         }
 
+        getBitAtIdx(args) {
+            if (args.AMOUNT > 31) return "";
+            let computeValue = args.NUM;
+            if (!(isItDecimal(computeValue) || isItHexadecimal(computeValue))) return "";
+            if (isItHexadecimal(computeValue) && /[abcdef]/i.test(computeValue)) {
+                computeValue = "0x" + computeValue;
+            }
+            return (computeValue >> args.IDX) & 1;
+        }
+
         signedRightShiftBitz(args) {
-            var computeValue = args.NUM;
+            let computeValue = args.NUM;
             if (!(isItDecimal(computeValue) || isItHexadecimal(computeValue))) return "";
             if (isItHexadecimal(computeValue) && /[abcdef]/i.test(computeValue)) {
                 computeValue = "0x" + computeValue;
@@ -449,7 +546,7 @@ function testForFormat(numString, base) {
         }
 
         leftShiftBitz(args) {
-            var computeValue = args.NUM;
+            let computeValue = args.NUM;
             if (!(isItDecimal(computeValue) || isItHexadecimal(computeValue))) return "";
             if (isItHexadecimal(computeValue) && /[abcdef]/i.test(computeValue)) {
                 computeValue = "0x" + computeValue;
@@ -459,7 +556,7 @@ function testForFormat(numString, base) {
         }
 
         unsignedRightShiftBitz(args) {
-            var computeValue = args.NUM;
+            let computeValue = args.NUM;
             if (!(isItDecimal(computeValue) || isItHexadecimal(computeValue))) return "";
             if (isItHexadecimal(computeValue) && /[abcdef]/i.test(computeValue)) {
                 computeValue = "0x" + computeValue;
@@ -469,7 +566,7 @@ function testForFormat(numString, base) {
         }
 
         circularRightShiftBitz(args) {
-            var computeValue = args.NUM;
+            let computeValue = args.NUM;
             if (!(isItDecimal(computeValue) || isItHexadecimal(computeValue))) return "";
             if (isItHexadecimal(computeValue) && /[abcdef]/i.test(computeValue)) {
                 computeValue = "0x" + computeValue;
@@ -479,7 +576,7 @@ function testForFormat(numString, base) {
         }
 
         circularLeftShiftBitz(args) {
-            var computeValue = args.NUM;
+            let computeValue = args.NUM;
             if (!(isItDecimal(computeValue) || isItHexadecimal(computeValue))) return "";
             if (isItHexadecimal(computeValue) && /[abcdef]/i.test(computeValue)) {
                 computeValue = "0x" + computeValue;
@@ -489,8 +586,8 @@ function testForFormat(numString, base) {
         }
 
         bitwiseAndOperator(args) {
-            var value1 = args.NUM;
-            var value2 = args.NUM2;
+            let value1 = args.NUM;
+            let value2 = args.NUM2;
             console.log(value1);
             console.log(value2);
             if (!(isItDecimal(value1) || isItHexadecimal(value2))) return "";
@@ -509,8 +606,8 @@ function testForFormat(numString, base) {
         }
 
         bitwiseOrOperator(args) {
-            var value1 = args.NUM;
-            var value2 = args.NUM2;
+            let value1 = args.NUM;
+            let value2 = args.NUM2;
             if (!(isItDecimal(value1) || isItHexadecimal(value2))) return "";
             if (!(isItDecimal(value2) || isItHexadecimal(value2))) return "";
             if (isItHexadecimal(value1) && /[abcdef]/i.test(value1)) {
@@ -527,8 +624,8 @@ function testForFormat(numString, base) {
         }
 
         bitwiseXorOperator(args) {
-            var value1 = args.NUM;
-            var value2 = args.NUM2;
+            let value1 = args.NUM;
+            let value2 = args.NUM2;
             if (!(isItDecimal(value1) || isItHexadecimal(value2))) return "";
             if (!(isItDecimal(value2) || isItHexadecimal(value2))) return "";
             if (isItHexadecimal(value1) && /[abcdef]/i.test(value1)) {
@@ -545,7 +642,7 @@ function testForFormat(numString, base) {
         }
 
         bitwiseNotOperator(args) {
-            var value1 = args.NUM;
+            let value1 = args.NUM;
             if (!(isItDecimal(value1) || isItHexadecimal(value2))) return "";
             if (isItHexadecimal(value1) && /[abcdef]/i.test(value1)) {
                 value1 = "0x" + value1;
@@ -558,8 +655,8 @@ function testForFormat(numString, base) {
         }
 
         bitwiseNandOperator(args) {
-            var value1 = args.NUM;
-            var value2 = args.NUM2;
+            let value1 = args.NUM;
+            let value2 = args.NUM2;
             if (!(isItDecimal(value1) || isItHexadecimal(value2))) return "";
             if (!(isItDecimal(value2) || isItHexadecimal(value2))) return "";
             if (isItHexadecimal(value1) && /[abcdef]/i.test(value1)) {
@@ -572,12 +669,12 @@ function testForFormat(numString, base) {
                 return "";
             }
 
-            return !(value1 & value2);
+            return ~(value1 & value2);
         }
 
         bitwiseNorOperator(args) {
-            var value1 = args.NUM;
-            var value2 = args.NUM2;
+            let value1 = args.NUM;
+            let value2 = args.NUM2;
             if (!(isItDecimal(value1) || isItHexadecimal(value2))) return "";
             if (!(isItDecimal(value2) || isItHexadecimal(value2))) return "";
             if (isItHexadecimal(value1) && /[abcdef]/i.test(value1)) {
@@ -590,12 +687,12 @@ function testForFormat(numString, base) {
                 return "";
             }
 
-            return !(value1 | value2);
+            return ~(value1 | value2);
         }
 
         bitwiseXnorOperator(args) {
-            var value1 = args.NUM;
-            var value2 = args.NUM2;
+            let value1 = args.NUM;
+            let value2 = args.NUM2;
             if (!(isItDecimal(value1) || isItHexadecimal(value2))) return "";
             if (!(isItDecimal(value2) || isItHexadecimal(value2))) return "";
             if (isItHexadecimal(value1) && /[abcdef]/i.test(value1)) {
@@ -608,7 +705,7 @@ function testForFormat(numString, base) {
                 return "";
             }
 
-            return !(value1 ^ value2);
+            return ~(value1 ^ value2);
         }
     }
     Scratch.extensions.register(new Extension());

--- a/static/extensions/BurningHot687/bitsandhexa.js
+++ b/static/extensions/BurningHot687/bitsandhexa.js
@@ -20,13 +20,41 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 */
 
-// V0.12
+// V0.13
 
 let fullLength = true;
 let extOpen = false;
 let basesArray = ["decimal", "binary", "hexadecimal"];
-const mainBlockArray = [];
-const extBlockArray = [];
+const extBlockArray = [
+    {
+        opcode: "bitHexConfigurationLabel",
+        text: "Configuration Settings ⚠",
+        blockType: Scratch.BlockType.LABEL,
+    },
+    {
+        opcode: "binaryLengthSetter",
+        text: "use a [LENGTH] length for binary",
+        blockType: Scratch.BlockType.COMMAND,
+        arguments: {
+            LENGTH: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "LENGTHS",
+            }
+        },
+    },
+    {
+        opcode: "binaryLengthGetter",
+        text: "using [LENGTH] length?",
+        blockType: Scratch.BlockType.BOOLEAN,
+        label: "using fixed length",
+        arguments: {
+            LENGTH: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "LENGTHS",
+            },
+        },
+    },
+];
 const icon = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAyMjUgMjI1Ij4KICA8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMjkuNS4xLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogMi4xLjAgQnVpbGQgMTQxKSAgLS0+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5zdDAgewogICAgICAgIGZpbGw6ICNmZmY7CiAgICAgIH0KCiAgICAgIC5zdDEgewogICAgICAgIGZpbGw6ICMxYjQ2OGQ7CiAgICAgIH0KCiAgICAgIC5zdDIgewogICAgICAgIGZpbGw6ICMxNDY0OGE7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDxyZWN0IGNsYXNzPSJzdDEiIHdpZHRoPSIyMjUiIGhlaWdodD0iMjI1Ii8+CiAgPGc+CiAgICA8cG9seWdvbiBjbGFzcz0ic3QwIiBwb2ludHM9IjE3NC4wNiAxNC4wMSAxMTkuMjEgMTQuMDEgOTEuNzkgNjEuNTEgMTE5LjIxIDEwOS4wMSAxNzQuMDYgMTA5LjAxIDIwMS40OSA2MS41MSAxNzQuMDYgMTQuMDEiLz4KICAgIDxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjY1LjY1IiBjeT0iMTIyLjI2IiByPSI0Mi4xNCIvPgogICAgPHJlY3QgY2xhc3M9InN0MCIgeD0iMTE3LjE3IiB5PSIxMTcuOCIgd2lkdGg9Ijc0LjE4IiBoZWlnaHQ9IjkzLjE5IiByeD0iMTIiIHJ5PSIxMiIvPgogIDwvZz4KPC9zdmc+";
 const iconCircle = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAyMjUgMjI1Ij4KICA8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMjkuNS4xLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogMi4xLjAgQnVpbGQgMTQxKSAgLS0+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5zdDAgewogICAgICAgIGZpbGw6ICMxNDY0OGE7CiAgICAgIH0KCiAgICAgIC5zdDEgewogICAgICAgIGZpbGw6ICNmZmY7CiAgICAgIH0KCiAgICAgIC5zdDIgewogICAgICAgIGZpbGw6ICMxYjQ2OGQ7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDxyZWN0IGNsYXNzPSJzdDIiIHg9IjAiIHk9IjAiIHdpZHRoPSIyMjUiIGhlaWdodD0iMjI1IiByeD0iMTEyLjUiIHJ5PSIxMTIuNSIvPgogIDxnPgogICAgPHBvbHlnb24gY2xhc3M9InN0MSIgcG9pbnRzPSIxNjMuODUgMzAuMzQgMTE4LjEgMzAuMzQgOTUuMjIgNjkuOTcgMTE4LjEgMTA5LjU5IDE2My44NSAxMDkuNTkgMTg2LjczIDY5Ljk3IDE2My44NSAzMC4zNCIvPgogICAgPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iNzMuNDIiIGN5PSIxMjAuNjQiIHI9IjM1LjE1Ii8+CiAgICA8cmVjdCBjbGFzcz0ic3QxIiB4PSIxMTYuNCIgeT0iMTE2LjkyIiB3aWR0aD0iNjEuODgiIGhlaWdodD0iNzcuNzQiIHJ4PSIxMC4wMSIgcnk9IjEwLjAxIi8+CiAgPC9nPgogIDxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik01MS41MSwxOTAuMjNjLTMuNjksMC0zLjY5LDUuNzMsMCw1LjczczMuNjktNS43MywwLTUuNzNaIi8+CiAgPHBhdGggY2xhc3M9InN0MSIgZD0iTTcwLjk3LDE3OS4wM2MtMy42OSwwLTMuNjksNS43MywwLDUuNzNzMy42OS01LjczLDAtNS43M1oiLz4KICA8cGF0aCBjbGFzcz0ic3QxIiBkPSJNNjYuNzcsMTkzLjF2MS40NGMtLjI2LS4xNS0uNTEtLjMtLjc2LS40NS0zLjE0LTEuOTYtNi4wMiwzLTIuODksNC45NSwxLjA3LjY3LDIuMTksMS4yMiwzLjM2LDEuNywxLjI4LjUzLDIuNjMsMS4wMywzLjk5LjQsMS42NS0uNzYsMi4wMy0yLjM2LDIuMDQtNC4wM3YtNC4wMWMwLTMuNjktNS43Mi0zLjY5LTUuNzMsMFoiLz4KPC9zdmc+";
 
@@ -98,6 +126,7 @@ function binaryToDecimal(computedValue) {
 
     class Extension {
         getInfo() {
+            const extraBlocks = extOpen ? extBlockArray : [];
             return {
                 id: "burninghot687bitwisewhexa",
                 name: Scratch.translate("Bits and Hexa"),
@@ -106,7 +135,7 @@ function binaryToDecimal(computedValue) {
                 color3: "#0a094f",
                 menuIconURI: iconCircle,
                 blockIconURI: icon,
-                // isDynamic: true,
+                isDynamic: true,
                 /*function orderBlocks(blocks) {
                     if (extOpen) {
                         return mainBlockArray.concat(extBlockArray);
@@ -385,35 +414,14 @@ function binaryToDecimal(computedValue) {
                         },
                         switches: [ 'bitwiseOrOperator', 'bitwiseXorOperator', 'bitwiseNotOperator', 'bitwiseNandOperator', 'bitwiseNorOperator', 'bitwiseAndOperator' ],
                     },
+                    "---",
                     {
-                        opcode: "bitHexConfigurationLabel",
-                        text: "Configuration Settings ⚠",
-                        blockType: Scratch.BlockType.LABEL,
+                        func: "openExtraBitwise",
+                        text: extOpen ? "Close Extras" : "Open Extras",
+                        blockType: Scratch.BlockType.BUTTON,
                     },
-                    {
-                        opcode: "binaryLengthSetter",
-                        text: "use a [LENGTH] length for binary",
-                        blockType: Scratch.BlockType.COMMAND,
-                        arguments: {
-                            LENGTH: {
-                                type: Scratch.ArgumentType.STRING,
-                                menu: "LENGTHS",
-                            }
-                        },
-                    },
-                    {
-                        opcode: "binaryLengthGetter",
-                        text: "using [LENGTH] length?",
-                        blockType: Scratch.BlockType.BOOLEAN,
-                        label: "using fixed length",
-                        arguments: {
-                            LENGTH: {
-                                type: Scratch.ArgumentType.STRING,
-                                menu: "LENGTHS",
-                            },
-                        },
-                    },
-                ],
+                    "---",
+                ].concat(extraBlocks),
                 menus: {
                     BASES: {
                         acceptReporters: false,
@@ -431,6 +439,11 @@ function binaryToDecimal(computedValue) {
             };
         }
         
+        openExtraBitwise() {
+            extOpen = !extOpen;
+            Scratch.vm.runtime.requestToolboxExtensionsUpdate();
+        }
+
         bitwiseDocumentationButton() {
             window.location.href = "https://docs.penguinmod.com/extensions/bitsandhexa";
         }


### PR DESCRIPTION
I still don't have that much testing, but finally dynamic length works for a case of 13 and -13 (10011 and 01101 respectively) Added a block to get bit at index and fixed bug with nand onwards (caused by logical not used instead of bitwise not)